### PR TITLE
WIP: Add initial changes to support prettier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 test/package.json
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -12,10 +12,10 @@
  */
 
 module.exports = {
+  parser: 'babel-eslint',
   extends: [
     'prettier',
-    'prettier/react',
-    'skyscanner',
+    'prettier/react'
   ],
   plugins: [
      'prettier'

--- a/index.js
+++ b/index.js
@@ -12,26 +12,15 @@
  */
 
 module.exports = {
-  parser: 'babel-eslint',
-  extends: 'airbnb',
+  extends: [
+    'prettier',
+    'prettier/react',
+    'skyscanner',
+  ],
+  plugins: [
+     'prettier'
+  ],
   rules: {
-    'valid-jsdoc': ['error'],
-
-    // Disabled whilst incompatibilities still exist with react/jsx-closing-tag-location, react/jsx-indent & max-len.
-    // See https://github.com/airbnb/javascript/issues/1584#issuecomment-335667272
-    "function-paren-newline": 0,
-
-    // Disabled whilst false positives still exist with custom propTypes + isRequired.
-    // See https://github.com/yannickcr/eslint-plugin-react/issues/1389
-    "react/no-typos": 0,
-
-    // Added 'to' as a specialLink property, which prevents react-router's
-    // 'Link' component from triggering this rule.
-    // See https://github.com/evcohen/eslint-plugin-jsx-a11y/issues/339
-    "jsx-a11y/anchor-is-valid": ["error", {
-      "components": ["Link"],
-      "specialLink": ["to"],
-      "aspects": ["noHref", "invalidHref", "preferButton"],
-    }]
+    'prettier/prettier': 'error'
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,0 @@
-{
-  "name": "eslint-config-skyscanner",
-  "version": "3.0.0",
-  "lockfileVersion": 1
-}

--- a/package.json
+++ b/package.json
@@ -17,12 +17,14 @@
     "javascript",
     "styleguide"
   ],
-  "peerDependencies": {
-    "eslint": "^4.9.0",
-    "eslint-config-skyscanner": "^3.0.0",
+  "dependencies": {
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-prettier": "^2.6.0",
     "prettier": "^1.12.1"
+  },
+  "peerDependencies": {
+    "babel-eslint": "^8.0.1",
+    "eslint": "^4.9.0"
   },
   "scripts": {
     "publish": "np",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "eslint-config-skyscanner",
-  "version": "2.0.0",
-  "description": "Skyscanner's ESLint config.",
+  "name": "eslint-config-skyscanner-with-prettier",
+  "version": "1.0.0",
+  "description": "Skyscanner's ESLint config, with prettier.",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Skyscanner/eslint-config-skyscanner"
+    "url": "https://github.com/Skyscanner/eslint-config-skyscanner-with-prettier"
   },
   "author": "Matthew Davidson <matthew.davidson@skyscanner.net>",
   "license": "Apache-2.0",
@@ -18,12 +18,11 @@
     "styleguide"
   ],
   "peerDependencies": {
-    "babel-eslint": "^8.0.1",
     "eslint": "^4.9.0",
-    "eslint-config-airbnb": "^16.1.0",
-    "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-jsx-a11y": "^6.0.2",
-    "eslint-plugin-react": "^7.4.0"
+    "eslint-config-skyscanner": "^3.0.0",
+    "eslint-config-prettier": "^2.9.0",
+    "eslint-plugin-prettier": "^2.6.0",
+    "prettier": "^1.12.1"
   },
   "scripts": {
     "publish": "np",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": "skyscanner"
+  "extends": "skyscanner-with-prettier"
 }

--- a/test/.package.json
+++ b/test/.package.json
@@ -10,12 +10,7 @@
   "author": "Tim von Oldenburg <tim.vonoldenburg@skyscanner.net>",
   "license": "Apache-2.0",
   "devDependencies": {
-    "babel-eslint": "^8.0.1",
-    "eslint-config-airbnb": "^16.1.0",
-    "eslint-config-skyscanner-with-prettier": "file:../",
-    "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-jsx-a11y": "^6.0.2",
-    "eslint-plugin-react": "^7.4.0"
+    "eslint-config-skyscanner-with-prettier": "file:../"
   },
   "scripts": {
     "test:pass": "echo 'Expecting pass' && eslint pass.jsx",

--- a/test/.package.json
+++ b/test/.package.json
@@ -10,7 +10,12 @@
   "author": "Tim von Oldenburg <tim.vonoldenburg@skyscanner.net>",
   "license": "Apache-2.0",
   "devDependencies": {
-    "eslint-config-skyscanner": "file:../"
+    "babel-eslint": "^8.0.1",
+    "eslint-config-airbnb": "^16.1.0",
+    "eslint-config-skyscanner-with-prettier": "file:../",
+    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-jsx-a11y": "^6.0.2",
+    "eslint-plugin-react": "^7.4.0"
   },
   "scripts": {
     "test:pass": "echo 'Expecting pass' && eslint pass.jsx",
@@ -20,5 +25,12 @@
   "dependencies": {
     "prop-types": "^15.5.10",
     "react": "^15.5.4"
+  },
+  "prettier": {
+    "semi": true,
+    "trailingComma": "all",
+    "singleQuote": true,
+    "arrowParens": "avoid",
+    "printWidth": 100
   }
 }

--- a/test/pass.jsx
+++ b/test/pass.jsx
@@ -1,11 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Banner = props => (
-  <div role="banner">
-    { props.children }
-  </div>
-);
+const Banner = props => <div role="banner">{props.children}</div>;
 
 Banner.propTypes = {
   children: PropTypes.node.isRequired,


### PR DESCRIPTION
Currently it's not easy or obvious how to add prettier into exiting skyscanner node/react projects. It involves adding new eslint configs and plugins, and prettier config.

So the idea is to provide an easy way to upgrade your current project to support prettier integration in eslint, and to encapsulate it in one place (via one package). 

We could provide a new eslint config package, that extends from `eslint-config-skyscanner`, but i don't think this is the best approach, as it means managing the `eslint-config-skyscanner` dependency within the new config package, when this is already managed by `backpack-react-scripts`.

A better approach might be to create a new eslint config package that doesn't extend from anything, but instead just wires up the various prettier eslint configs and plugins. It also installs it's own dependencies (and thus no change required to `backpack-react-scripts`).

Then in the root project, you "opt in" by installing the `eslint-config-skyscanner-with-prettier` as a `devDependency`, then update your eslintrc config:

```json
{
  "extends": [
    "skyscanner",
    "skyscanner-with-prettier"
  ]
}
```

Unfortunately I don't think we can encapsulate the prettier config within this new package. Much like eslint, a config file at root (or in `package.json`) needs to exist.

The user will need to manually create a `prettier.config.js` file with the following contents:

```
module.exports = require('prettier-config-skyscanner');
```

The prettier config I have been using is:

```json
{
  "semi": true,
  "trailingComma": "all",
  "singleQuote": true,
  "arrowParens": "avoid",
  "printWidth": 100
}
```

I am not sold on `-with-prettier` but have struggled for a better name.